### PR TITLE
Reducing Bitmap Size for Face Detection and Landmark Tracking

### DIFF
--- a/holotrack/Tracking/FaceTracker.cs
+++ b/holotrack/Tracking/FaceTracker.cs
@@ -36,21 +36,47 @@ namespace holotrack.Tracking
         /// The number of faces being tracked
         /// </summary>
         public int Tracked => Faces?.Count ?? 0;
- 
+
         public bool IsTracking => Tracked > 0;
 
-        float _scale = float.MaxValue;
-        public float DetectScale
+        float _detectionScale = float.MaxValue;
+        /// <summary>
+        /// The scale factor of face detection. If this value is float.MaxValue, scale factor is automatically decide by maximum pixel size (MaxDetectionSize)
+        /// </summary>
+        public float FaceDetectionScale
         {
-            get => _scale;
-            set =>_scale = value;
+            get => _detectionScale;
+            set => _detectionScale = value;
         }
 
-        int _maxSize = 350;
-        public int MaxSize
+        float _landmarkScale = float.MaxValue;
+        /// <summary>
+        /// The scale factor of face landmark tracking. If this value is float.MaxValue, scale factor is automatically decide by maximum pixel size (MaxLandmarkSize)
+        /// </summary>
+        public float FaceLandmarkScale
         {
-            get => _maxSize;
-            set => _maxSize = value;
+            get => _landmarkScale;
+            set => _landmarkScale = value;
+        }
+
+        int _maxDetectionSize = 200;
+        /// <summary>
+        /// Maximum image size for detection, this value is applied first. Increasing this value to find more smaller face in far place. But it may loss performance.
+        /// </summary>
+        public int MaxDetectionSize
+        {
+            get => _maxDetectionSize;
+            set => _maxDetectionSize = value;
+        }
+
+        int _maxLandmarkSize = 520;
+        /// <summary>
+        /// Maximum image size for detection, this value is applied first.
+        /// </summary>
+        public int MaxLandmarkSize
+        {
+            get => _maxLandmarkSize;
+            set => _maxLandmarkSize = value;
         }
 
         public event Action<IReadOnlyList<Face>> OnTrackerUpdate;
@@ -82,18 +108,33 @@ namespace holotrack.Tracking
                 var mstream = new MemoryStream(camera.CaptureData);
                 var raw_bitmap = new Bitmap(mstream);
 
-                var scale = _scale;
-                if (scale == float.MaxValue)
+                var detectionScale = _detectionScale == float.MaxValue ?
+                    (float)_maxDetectionSize / Math.Max(_maxDetectionSize, Math.Max(raw_bitmap.Width, raw_bitmap.Height)) : _detectionScale;
+                var landmarkScale = _landmarkScale == float.MaxValue ?
+                    (float)_maxLandmarkSize / Math.Max(_maxLandmarkSize, Math.Max(raw_bitmap.Width, raw_bitmap.Height)) : _landmarkScale;
+
+                var detectionBitmap = new Bitmap(raw_bitmap,
+                    new System.Drawing.Size((int)(raw_bitmap.Width * detectionScale), (int)(raw_bitmap.Height * detectionScale)));
+                var landmarkBitmap = new Bitmap(raw_bitmap,
+                    new System.Drawing.Size((int)(raw_bitmap.Width * landmarkScale), (int)(raw_bitmap.Height * landmarkScale)));
+
+                var detectionImage = FaceRecognition.LoadImage(detectionBitmap);
+                var landmarkImage = FaceRecognition.LoadImage(landmarkBitmap);
+
+                var locations = faceRecognition.FaceLocations(detectionImage).ToArray();
+                for (int i = 0; i < locations.Length; i++)
                 {
-                    scale = (float)_maxSize / Math.Max(_maxSize, Math.Max(raw_bitmap.Width, raw_bitmap.Height));
+                    var item = locations[i];
+                    locations[i] = new Location(
+                        (int)((float)item.Left / detectionScale * landmarkScale),
+                        (int)((float)item.Top / detectionScale * landmarkScale),
+                        (int)((float)item.Right / detectionScale * landmarkScale),
+                        (int)((float)item.Bottom / detectionScale * landmarkScale)
+                        );
                 }
+                var landmarks = faceRecognition.FaceLandmark(landmarkImage, locations).ToArray();
 
-                var bitmap = new Bitmap(raw_bitmap, new System.Drawing.Size((int)(raw_bitmap.Width * scale), (int)(raw_bitmap.Height * scale)));
-
-                var image = FaceRecognition.LoadImage(bitmap);
-                var locations = faceRecognition.FaceLocations(image).ToArray();
-                var landmarks = faceRecognition.FaceLandmark(image, locations).ToArray();
-
+                var scale = landmarkScale;
                 faces = new List<Face>();
 
                 for (int i = 0; i < locations.Length; i++)
@@ -102,10 +143,10 @@ namespace holotrack.Tracking
 
                     var marks = landmarks[i];
                     var new_marks = new Dictionary<FacePart, IEnumerable<FacePoint>>();
-                    foreach(var key in marks.Keys)
+                    foreach (var key in marks.Keys)
                     {
                         var point_list = new List<FacePoint>();
-                        foreach(var point in marks[key])
+                        foreach (var point in marks[key])
                         {
                             point_list.Add(new FacePoint(
                                 new FaceRecognitionDotNet.Point((int)(point.Point.X / scale), (int)(point.Point.Y / scale)),
@@ -118,13 +159,17 @@ namespace holotrack.Tracking
                     faces.Add(new Face
                     {
                         Landmarks = new_marks,
-                        BoundingBox = new RectangleF((float)loc.Left / scale, (float)loc.Top / scale, 
+                        BoundingBox = new RectangleF((float)loc.Left / scale, (float)loc.Top / scale,
                                                      (float)(loc.Right - loc.Left) / scale, (float)(loc.Bottom - loc.Top) / scale)
                     });
                 }
 
-                image.Dispose();
-                bitmap.Dispose();
+                landmarkImage.Dispose();
+                detectionImage.Dispose();
+
+                landmarkBitmap.Dispose();
+                detectionBitmap.Dispose();
+
                 raw_bitmap.Dispose();
                 mstream.Dispose();
 


### PR DESCRIPTION
Reducing bitmap Size for face detection and landmark tracking.

Max size of face detection bitmap set as 200px, and the size of the landmark tracking bitmap set as 540px.

Achieved 0.025 delta time.