### PR TITLE
Make Face Tracker component abstract

### DIFF
--- a/holotrack/HoloTrackGameBase.cs
+++ b/holotrack/HoloTrackGameBase.cs
@@ -1,4 +1,3 @@
-using FaceRecognitionDotNet;
 using holotrack.Configuration;
 using osu.Framework;
 using osu.Framework.Allocation;
@@ -36,9 +35,6 @@ namespace holotrack
             dependencies.Cache(cameraManager);
 
             dependencies.Cache(LocalConfig);
-
-            // Temporarily read the models in the output directory. We'll have a better support for embedded resources at a later date.
-            dependencies.Cache(FaceRecognition.Create($"{RuntimeInfo.StartupDirectory}/models"));
 
             AddFont(Resources, @"Fonts/NotoExtraCond");
             AddFont(Resources, @"Fonts/NotoExtraCond-Italic");

--- a/holotrack/Tracking/Face.cs
+++ b/holotrack/Tracking/Face.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using osu.Framework.Graphics.Primitives;
+using osuTK;
+
+namespace holotrack.Tracking
+{
+    public struct Face
+    {
+        public Dictionary<FacePart, List<Vector2>> Landmarks;
+        public RectangleF Bounds;
+    }
+}

--- a/holotrack/Tracking/Face.cs
+++ b/holotrack/Tracking/Face.cs
@@ -6,7 +6,7 @@ namespace holotrack.Tracking
 {
     public struct Face
     {
-        public Dictionary<FacePart, List<Vector2>> Landmarks;
+        public Dictionary<FacePart, IEnumerable<Vector2>> Landmarks;
         public RectangleF Bounds;
     }
 }

--- a/holotrack/Tracking/FacePart.cs
+++ b/holotrack/Tracking/FacePart.cs
@@ -1,0 +1,16 @@
+namespace holotrack.Tracking
+{
+    public enum FacePart
+    {
+        Chin,
+        LeftEyebrow,
+        RightEyebrow,
+        LeftEye,
+        RightEye,
+        Nose,
+        NoseBridge,
+        NoseTip,
+        TopLip,
+        BottomLip,
+    }
+}

--- a/holotrack/Tracking/FaceRecognitionDotNetFaceTracker.cs
+++ b/holotrack/Tracking/FaceRecognitionDotNetFaceTracker.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FaceRecognitionDotNet;
+using osu.Framework;
+using osuTK;
+using Bitmap = System.Drawing.Bitmap;
+using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
+
+namespace holotrack.Tracking
+{
+    public class FaceRecognitionDotNetFaceTracker : FaceTracker
+    {
+        // Face Tracking models should be placed in the output directory in the meantime
+        private static FaceRecognition face_recognition => FaceRecognition.Create($"{RuntimeInfo.StartupDirectory}/models");
+
+        protected override void UpdateState(List<Face> faces)
+        {
+            var bitmap = new Bitmap(new MemoryStream(Camera.CaptureData));
+            var image = FaceRecognition.LoadImage(bitmap);
+            var locations = face_recognition.FaceLocations(image).ToArray();
+            var landmarks = face_recognition.FaceLandmark(image, locations).ToArray();
+
+            for (int i = 0; i < locations.Length; i++)
+            {
+                var location = locations[i];
+                var landmark = landmarks[i];
+
+                var landmarkDict = new Dictionary<FacePart, List<Vector2>>();
+                foreach (var (part, points) in landmark)
+                {
+                    var pointsList = new List<Vector2>();
+                    foreach (var p in points)
+                        pointsList.Add(new Vector2(p.Point.X, p.Point.Y));
+
+                    landmarkDict.Add(fromFaceRecognitionFacePart(part), pointsList);
+                }
+
+                faces.Add(new Face
+                {
+                    Landmarks = landmarkDict,
+                    Bounds = new RectangleF((float)location.Left, (float)location.Top, (float)(location.Right - location.Left), (float)(location.Bottom - location.Top))
+                });
+            }
+        }
+
+        private FacePart fromFaceRecognitionFacePart(FaceRecognitionDotNet.FacePart part)
+        {
+            switch (part)
+            {
+                case FaceRecognitionDotNet.FacePart.Chin:
+                    return FacePart.Chin;
+                case FaceRecognitionDotNet.FacePart.LeftEyebrow:
+                    return FacePart.LeftEyebrow;
+                case FaceRecognitionDotNet.FacePart.RightEyebrow:
+                    return FacePart.RightEyebrow;
+                case FaceRecognitionDotNet.FacePart.LeftEye:
+                    return FacePart.LeftEye;
+                case FaceRecognitionDotNet.FacePart.RightEye:
+                    return FacePart.RightEye;
+                case FaceRecognitionDotNet.FacePart.TopLip:
+                    return FacePart.TopLip;
+                case FaceRecognitionDotNet.FacePart.BottomLip:
+                    return FacePart.BottomLip;
+                case FaceRecognitionDotNet.FacePart.Nose:
+                    return FacePart.Nose;
+                case FaceRecognitionDotNet.FacePart.NoseTip:
+                    return FacePart.NoseTip;
+                case FaceRecognitionDotNet.FacePart.NoseBridge:
+                    return FacePart.NoseBridge;
+                default:
+                    throw new ArgumentException($"{nameof(part)} is not a valid FacePart.");
+            }
+        }
+    }
+}

--- a/holotrack/Tracking/FaceTracker.cs
+++ b/holotrack/Tracking/FaceTracker.cs
@@ -21,35 +21,17 @@ namespace holotrack.Tracking
         /// <summary>
         /// A collection of tracked faces
         /// </summary>
-        public IReadOnlyList<Face> Faces 
-        {
-            get
-            {
-                lock (faces) return faces.ToArray();
-            }
-        }
+        public IReadOnlyList<Face> Faces => faces.ToArray();
 
         /// <summary>
         /// The number of faces being tracked
         /// </summary>
-        public int Tracked
-        {
-            get
-            {
-                lock (faces) return faces.Count;
-            }
-        }
+        public int Tracked => faces.Count;
 
         /// <summary>
         /// A check if there is at least one face is being tracked
         /// </summary>
-        public bool IsTracking
-        {
-            get
-            {
-                lock (faces) return faces.Count > 0;
-            }
-        }
+        public bool IsTracking => faces.Count > 0;
 
         private double lastTrack;
 


### PR DESCRIPTION
This allows us to smoothly transition to other libraries in future milestones and phases. Added proper documentation to go along with it. This also introduces two new things:

* `FacePart` is an enumeration of face parts based on `FaceRecognitionDotNet.FacePart` made to not rely on it's version when we move out.
* `Face` is a struct that has `Dictionary<FacePart, List<Vector2>> Landmarks`  and `osu.Framework.Graphics.Primitives.RectangleF Locations` to make it easily usable with osu!framework and not rely on `FaceRecognitionDotNet` once it gets removed.

See  `FaceRecognitionDotNetFaceTracker` for example usage. 