### PR TITLE
Add a naive approach to facial feature tracking

### DIFF
--- a/Vignette.Application.Tests/Visual/Recognition/TestSceneEyePupilTracking.cs
+++ b/Vignette.Application.Tests/Visual/Recognition/TestSceneEyePupilTracking.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2020 - 2021 Vignette Project
+// Licensed under NPOSLv3. See LICENSE for details.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+using Vignette.Application.Recognition;
+
+namespace Vignette.Application.Tests.Visual.Recognition
+{
+    public class TestSceneEyePupilTracking : TestSceneRecognition
+    {
+        private FaceTracker tracker;
+
+        private readonly SpriteText positionDisplay;
+
+        public TestSceneEyePupilTracking()
+        {
+            Add(positionDisplay = new SpriteText { Margin = new MarginPadding(5) });
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            var l = tracker.GetEyePupilPosition(FaceRegion.LeftEye) ?? Vector2.Zero;
+            var r = tracker.GetEyePupilPosition(FaceRegion.RightEye) ?? Vector2.Zero;
+            positionDisplay.Text = $@"Left Eye: ({l.X},{l.Y}) | Right Eye: ({r.X},{r.Y})";
+        }
+
+        protected override void TrackerChanged(FaceTracker tracker) => this.tracker = tracker;
+    }
+}

--- a/Vignette.Application.Tests/Visual/Recognition/TestSceneRecognition.cs
+++ b/Vignette.Application.Tests/Visual/Recognition/TestSceneRecognition.cs
@@ -42,12 +42,6 @@ namespace Vignette.Application.Tests.Visual.Recognition
 
         private readonly BasicDropdown<CameraType> cameraTypeSelector;
 
-        private static readonly ImageEncodingParam[] encodingparams = new[]
-        {
-            new ImageEncodingParam(ImwriteFlags.JpegQuality, 100),
-            new ImageEncodingParam(ImwriteFlags.JpegOptimize, 50),
-        };
-
         public TestSceneRecognition()
         {
             cameraManager = createSuitableCameraManager(Scheduler);
@@ -141,7 +135,7 @@ namespace Vignette.Application.Tests.Visual.Recognition
                         break;
 
                     case CameraType.Virtual:
-                        Camera = new CameraVirtual(VignetteTestResources.GetResource(@"bakamitai_deepfake_template.mp4"), EncodingFormat.JPEG, encodingparams);
+                        Camera = new CameraVirtual(VignetteTestResources.GetResource(@"bakamitai_deepfake_template.mp4"));
                         cameraSpriteContainer.Add(cameraSprite = new DrawableCameraVirtual((CameraVirtual)Camera));
                         virtualCameraControls.Alpha = 1.0f;
                         physicalCameraControls.Alpha = 0.0f;
@@ -171,7 +165,7 @@ namespace Vignette.Application.Tests.Visual.Recognition
                 if (cameraSprite is DrawableCameraDevice drawableCameraDevice)
                     drawableCameraDevice.Expire();
 
-                Camera = new CameraDevice(Array.IndexOf(cameraManager.CameraDeviceNames.ToArray(), cam.NewValue), EncodingFormat.JPEG, encodingparams);
+                Camera = new CameraDevice(Array.IndexOf(cameraManager.CameraDeviceNames.ToArray(), cam.NewValue));
                 cameraSpriteContainer.Add(cameraSprite = new DrawableCameraDevice((CameraDevice)Camera));
             };
         }

--- a/Vignette.Application/Recognition/FaceTracker.cs
+++ b/Vignette.Application/Recognition/FaceTracker.cs
@@ -6,11 +6,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Graphics;
+using osuTK;
 using Vignette.Application.Camera;
 
 namespace Vignette.Application.Recognition
 {
-    public abstract class FaceTracker : Component
+    public abstract class FaceTracker : Component, IFaceTracker
     {
         public IReadOnlyList<Face> Faces => faces?.ToArray();
 
@@ -35,6 +36,16 @@ namespace Vignette.Application.Recognition
         public virtual void StopTracking() => Camera = null;
 
         protected abstract IEnumerable<Face> Track();
+
+        public abstract Vector3? GetHeadAngles(int index = 0);
+
+        public abstract Vector2? GetHeadPosition(int index = 0);
+
+        public abstract Vector2? GetEyePupilPosition(FaceRegion eye, int headIndex = 0);
+
+        public abstract float? GetEyeLidOpen(FaceRegion eye, int headIndex = 0);
+
+        public abstract float? GetMouthOpen(int index = 0);
 
         protected override void LoadComplete()
         {

--- a/Vignette.Application/Recognition/IFaceTracker.cs
+++ b/Vignette.Application/Recognition/IFaceTracker.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2020 - 2021 Vignette Project
+// Licensed under NPOSLv3. See LICENSE for details.
+
+using System.Collections.Generic;
+using osuTK;
+using Vignette.Application.Camera;
+
+namespace Vignette.Application.Recognition
+{
+    public interface IFaceTracker
+    {
+        public IReadOnlyList<Face> Faces { get; }
+
+        public int Tracked { get; }
+
+        public double Delta { get; }
+
+        public void StartTracking(ICamera camera);
+
+        public void StopTracking();
+
+        public Vector3? GetHeadAngles(int index = 0);
+
+        public Vector2? GetHeadPosition(int index = 0);
+
+        public Vector2? GetEyePupilPosition(FaceRegion eye, int headIndex = 0);
+
+        public float? GetEyeLidOpen(FaceRegion eye, int headIndex = 0);
+
+        public float? GetMouthOpen(int index = 0);
+    }
+}


### PR DESCRIPTION
Add a naïve approach in tracking facial features. This also lays the groundwork in tracking facial features for possible replacements in the future.

**Facial Features**
- [x] Eye Pupils
This tracks the pupil of the eye. The region of interest has an applied grayscale and blur to be able to find the pupil which is usually the black region in the eye.
- [ ] Eye Lids
- [ ] Mouth Open
- [ ] Head Position
- [ ] Head Angles