### PR TITLE
Update README to reflect current roadmap

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
-file_header_template = Copyright 2020 - 2021 Vignette Project\nLicensed under NPOSLv3. See LICENSE for details.
+file_header_template = Copyright 2020 - 2021 Vignette Project\nLicensed under NPOSL-3.0. See LICENSE for details.
 
 #Roslyn naming styles
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ dotnet run --project Vignette.Desktop
 Please make sure you meet the prerequisites:
 - A desktop platform with [.NET 5.0 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) installed.
 - Have provided proper credentials to access the [GitHub Packages](https://github.com/orgs/vignette-project/packages).
-- Provide your own copy of the [Live2D Cubism SDK](https://www.live2d.com/en/download/cubism-sdk/).
 
 ### Setting up GitHub Packages
 

--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Vignette is Copyright &copy; 2020 Ayane Satomi and the Vignette Authors, license
 
 ## Commercial Use
 
-While Vignette is NPOSLv3, for-profit agencies who wish to use Vignette for their performers, please contact [Ayane Satomi](mailto:chinodesuuu@gmail.com) for a negotiation.
+While Vignette is NPOSLv3, for-profit agencies who wish to use Vignette for their performers, please [open a ticket](mailto:support@vignette-project.atlassian.net) for a negotiation.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The style guide is defined in the [`.editorconfig`](./.editorconfig) at the root
 
 ## License
 
-Vignette is Copyright &copy; 2020 Ayane Satomi and the Vignette Authors, licensed under Non-Profit Open Source License v3.0. For the full license text please see the [LICENSE](./LICENSE.md) file in this repository.
+Vignette is Copyright &copy; 2020 Ayane Satomi and the Vignette Authors, licensed under Non-Profit Open Source License v3.0 (NPOSL-3.0). For the full license text please see the [LICENSE](./LICENSE.md) file in this repository.
 
 ## Commercial Use
 


### PR DESCRIPTION
Currently we're still having some few references of the old design so this is a minor change to update properly. This will also change the license header template to use the valid SPDX for NPOSL-3.0