### PR TITLE
Fix incorrect default theme

### DIFF
--- a/Vignette.Application/Configuration/ApplicationConfigManager.cs
+++ b/Vignette.Application/Configuration/ApplicationConfigManager.cs
@@ -17,7 +17,7 @@ namespace Vignette.Application.Configuration
 
         protected override void InitialiseDefaults()
         {
-            SetValue(ApplicationSetting.Theme, @"Default");
+            SetValue(ApplicationSetting.Theme, @"default");
             SetValue(ApplicationSetting.WindowResizable, false);
             SetValue(ApplicationSetting.ShowFpsOverlay, false);
             SetValue(ApplicationSetting.Background, BackgroundType.Color);


### PR DESCRIPTION
Fixes #168 
Resources loaded from the filesystem appear to have case sensitive names - the default theme is named [`default.json`](https://github.com/vignette-project/vignette/blob/dbda89d6a74728fcd34140c8d2614216e4cbed50/Vignette.Application/Resources/Themes/default.json)

https://github.com/vignette-project/vignette/blob/dbda89d6a74728fcd34140c8d2614216e4cbed50/Vignette.Application/Graphics/Themes/ThemeStore.cs#L29-L33