### PR TITLE
Show a different home banner for insider releases

### DIFF
--- a/Vignette.Game/Screens/Menu/Home/HomeBanner.cs
+++ b/Vignette.Game/Screens/Menu/Home/HomeBanner.cs
@@ -17,9 +17,8 @@ namespace Vignette.Game.Screens.Menu.Home
     {
         private Box background;
 
-        private static Colour4 gradient_part_a = Colour4.FromHex("BE58CB");
-
-        private static Colour4 gradient_part_b = Colour4.FromHex("F10E5A");
+        [Resolved]
+        private VignetteGameBase game { get; set; }
 
         public HomeBanner()
         {
@@ -35,7 +34,7 @@ namespace Vignette.Game.Screens.Menu.Home
                 background = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = ColourInfo.GradientHorizontal(gradient_part_a, gradient_part_b),
+                    Colour = getGradient(),
                 },
                 new Container
                 {
@@ -88,10 +87,31 @@ namespace Vignette.Game.Screens.Menu.Home
         {
             base.LoadComplete();
             background
-                .FadeColour(ColourInfo.GradientHorizontal(gradient_part_b, gradient_part_a), 5000, Easing.InSine)
+                .FadeColour(getGradient(), 5000, Easing.InSine)
                 .Then()
-                .FadeColour(ColourInfo.GradientHorizontal(gradient_part_a, gradient_part_b), 5000, Easing.OutSine)
+                .FadeColour(getGradient(true), 5000, Easing.OutSine)
                 .Loop();
+        }
+
+        private static Colour4 grad_pub_a = Colour4.FromHex("BE58CB");
+        private static Colour4 grad_pub_b = Colour4.FromHex("F10E5A");
+        private static Colour4 grad_ins_a = Colour4.FromHex("58CB86");
+        private static Colour4 grad_ins_b = Colour4.FromHex("0EBBF1");
+
+        private ColourInfo getGradient(bool flipped = false)
+        {
+            if (game.IsInsidersBuild)
+            {
+                return flipped
+                    ? ColourInfo.GradientHorizontal(grad_ins_b, grad_ins_a)
+                    : ColourInfo.GradientHorizontal(grad_ins_a, grad_ins_b);
+            }
+            else
+            {
+                return flipped
+                    ? ColourInfo.GradientHorizontal(grad_pub_b, grad_pub_a)
+                    : ColourInfo.GradientHorizontal(grad_pub_a, grad_pub_b);
+            }
         }
     }
 }

--- a/Vignette.Game/VignetteGameBase.cs
+++ b/Vignette.Game/VignetteGameBase.cs
@@ -2,6 +2,7 @@
 // Licensed under NPOSLv3. See LICENSE for details.
 
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -41,6 +42,8 @@ namespace Vignette.Game
         }
 
         public bool IsDeployedBuild => AssemblyVersion.Major > 0;
+
+        public bool IsInsidersBuild => FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion.Contains("insiders");
 
         protected Storage Storage;
 


### PR DESCRIPTION
A different gradient for insiders. Also adds a new property in `VignetteGameBase` to be able to tell whether this is an insiders release.
![image](https://user-images.githubusercontent.com/20495991/117564543-1ca98780-b0df-11eb-898a-63895fe6ca44.png)

App Icon and theme stay the same to keep brand identity still alive.
