### PR TITLE
Add character limits to textboxes

### DIFF
--- a/Vignette.Game/Settings/Components/SettingsFileBrowser.cs
+++ b/Vignette.Game/Settings/Components/SettingsFileBrowser.cs
@@ -17,7 +17,7 @@ namespace Vignette.Game.Settings.Components
     {
         protected virtual string[] Extensions => null;
 
-        protected override FluentTextBox CreateControl() => new FluentTextBox { RelativeSizeAxes = Axes.X };
+        protected override FluentTextBox CreateControl() => new FluentTextBox { RelativeSizeAxes = Axes.X, CharacterLimit = 10000 };
 
         private readonly Bindable<FileInfo> currentDirectory = new Bindable<FileInfo>();
 

--- a/Vignette.Game/Settings/SettingsHeader.cs
+++ b/Vignette.Game/Settings/SettingsHeader.cs
@@ -63,6 +63,7 @@ namespace Vignette.Game.Settings
                             Width = 250,
                             Anchor = Anchor.BottomCentre,
                             Origin = Anchor.BottomCentre,
+                            CharacterLimit = 30
                         }
                     }
                 },


### PR DESCRIPTION
Our textboxes can not handle the full raw text of Moby Dick. If you copy and paste a very large block of text into a text box the program will lock itself up. There is no option to disable copy/pasting in an o!f TextBox so instead I limited the search text box to 30 characters (the longest thing you can search up currently is 28 characters). For the FileBrowser textbox, I limited it to 10,000 characters (hopefully this is enough for most file paths).