### PR TITLE
Fix "typo" error for backdrop section: colour

### DIFF
--- a/Vignette.Game/Settings/Sections/BackdropSection.cs
+++ b/Vignette.Game/Settings/Sections/BackdropSection.cs
@@ -69,7 +69,7 @@ namespace Vignette.Game.Settings.Sections
                                     new SettingsColourPicker
                                     {
                                         Icon = SegoeFluent.ColorBackground,
-                                        Label = "Background Color",
+                                        Label = "Background Colour",
                                         Current = config.GetBindable<Colour4>(VignetteSetting.BackgroundColour),
                                     }
                                 },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59031302/136651979-c6cd574b-ac9f-4796-8ca3-5ca7a3a1f82d.png)
color becomes "colour" so it fits the dropdown