### PR TITLE
Fix "Computer" button crashing the app on linux

### DIFF
--- a/Vignette.Game/Settings/Components/SettingsDirectoryBrowser.cs
+++ b/Vignette.Game/Settings/Components/SettingsDirectoryBrowser.cs
@@ -2,7 +2,6 @@
 // Licensed under NPOSLv3. See LICENSE for details.
 
 using System.IO;
-using FFmpeg.AutoGen;
 using osu.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;


### PR DESCRIPTION
Now it points to "/".

Not sure if this is the way of doing it, but it works.