### PR TITLE
Add Asar ContentLoader

### DIFF
--- a/source/Vignette/Audio/AudioManager.cs
+++ b/source/Vignette/Audio/AudioManager.cs
@@ -166,7 +166,7 @@ public sealed class AudioManager : IObjectPool<AudioBuffer>
 
             source.Stop();
 
-            while(source.TryDequeue(out var buffer))
+            while (source.TryDequeue(out var buffer))
             {
                 bufferPool.Return(buffer);
             }

--- a/source/Vignette/Content/AsarLoader.cs
+++ b/source/Vignette/Content/AsarLoader.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cosyne 
+// Licensed under GPL 3.0 with SDK Exception. See LICENSE for details.
+
+using craftersmine.Asar.Net;
+using System;
+using System.IO;
+
+namespace Vignette.Content;
+internal class AsarLoader : IContentLoader<AsarArchive>
+{
+    // while the library is capable of verifying if its a valid archive, we would like to do
+    // it in the content loader level too so we can catch masquerading malicious files as we
+    // load them.
+    // The first 4 bytes of an asar archive is 04 00 00 00.
+    private static readonly byte[] signature = new byte[] { 0x04, 0x00, 0x00, 0x00 };
+
+    public AsarArchive Load(ReadOnlySpan<byte> bytes)
+    {
+        if (!MemoryExtensions.SequenceEqual(bytes[0..4], signature))
+            throw new ArgumentException("Failed to find sequence \"04 00 00 00\" in byte sequence.", nameof(bytes));
+
+        // read the bytes into a stream
+        var stream = new MemoryStream(bytes.ToArray());
+        return new AsarArchive(stream);
+    }
+}

--- a/source/Vignette/Content/AsarLoader.cs
+++ b/source/Vignette/Content/AsarLoader.cs
@@ -1,9 +1,9 @@
-// Copyright (c) Cosyne 
+// Copyright (c) Cosyne
 // Licensed under GPL 3.0 with SDK Exception. See LICENSE for details.
 
-using craftersmine.Asar.Net;
 using System;
 using System.IO;
+using craftersmine.Asar.Net;
 
 namespace Vignette.Content;
 internal class AsarLoader : IContentLoader<AsarArchive>

--- a/source/Vignette/Graphics/IProjector.cs
+++ b/source/Vignette/Graphics/IProjector.cs
@@ -19,7 +19,7 @@ public interface IProjector
     /// <summary>
     /// The projector's rotation.
     /// </summary>
-    Vector3 Rotation  { get; }
+    Vector3 Rotation { get; }
 
     /// <summary>
     /// The projector's view matrix.

--- a/source/Vignette/Vignette.csproj
+++ b/source/Vignette/Vignette.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Sekai" Version="0.1.0-alpha.9" />
     <PackageReference Include="StbiSharp" Version="1.2.1" />
+    <PackageReference Include="craftersmine.Asar.Net" Version="1.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds core basic functionality to load an Asar Archive. While the library does come with its own verification, we would love to do it in the loader level too for security reasons so we can patch up reading the archives before the library ever reads it.